### PR TITLE
Let upload file transfer wait longer for completion

### DIFF
--- a/src/main/java/S3.java
+++ b/src/main/java/S3.java
@@ -234,7 +234,7 @@ public class S3 {
 					} catch (AmazonServiceException e) {
 
 					} catch (SdkClientException e) {
- 
+
 					}
 				}
 			}
@@ -416,12 +416,22 @@ public class S3 {
 	}
 
 	public Upload UploadFileHLAPI(AmazonS3 svc, String bucket, String key, String filePath) {
-		TransferManager tm = TransferManagerBuilder.standard().withS3Client(svc).build();
+		TransferManager tm = TransferManagerBuilder.standard().withS3Client(svc)
+				.withMinimumUploadPartSize(10 * 1024 * 1024l).build();
 		Upload upload = tm.upload(bucket, key, new File(filePath));
 		try {
 			waitForCompletion(upload);
 		} catch (AmazonServiceException e) {
 
+		}
+		int waitForDone = 0;
+		if (!upload.isDone() && waitForDone < 10){
+			try {
+				Thread.sleep(10 * 1000l);
+			} catch (InterruptedException e) {
+
+			}
+			waitForDone++;
 		}
 		return upload;
 	}


### PR DESCRIPTION
Due to frequent failures of the **AWS4Test.testUploadFileHLAPIBigFileAWS4** a loop was added after the upload transfer's _waitForCompletion()_ method in order to allow file parts to be merged on machines when writing is delayed and the _isDone()_ status is not true at the assertion: **(java.lang.AssertionError at AWS4Test.java:792)**. 

A discussion at [https://github.com/aws/aws-sdk-java/issues/1277](https://github.com/aws/aws-sdk-java/issues/1277) indicates that when using a transfer manager, despite getting a successful outcome from waitForCompletion() which seems to carry the meaning of all parts being uploaded, the isDone() value does not become true until they are merged into a whole file.

Signed-off-by: Antoaneta Damyanova <adamyanova@gmail.com>