### PR TITLE
Update failing test functionality

### DIFF
--- a/src/main/java/S3.java
+++ b/src/main/java/S3.java
@@ -417,21 +417,12 @@ public class S3 {
 
 	public Upload UploadFileHLAPI(AmazonS3 svc, String bucket, String key, String filePath) {
 		TransferManager tm = TransferManagerBuilder.standard().withS3Client(svc)
-				.withMinimumUploadPartSize(10 * 1024 * 1024l).build();
+				.build();
 		Upload upload = tm.upload(bucket, key, new File(filePath));
 		try {
 			waitForCompletion(upload);
 		} catch (AmazonServiceException e) {
 
-		}
-		int waitForDone = 0;
-		if (!upload.isDone() && waitForDone < 10){
-			try {
-				Thread.sleep(10 * 1000l);
-			} catch (InterruptedException e) {
-
-			}
-			waitForDone++;
 		}
 		return upload;
 	}
@@ -488,5 +479,4 @@ public class S3 {
 
 		}
 	}
-
 }

--- a/src/test/java/AWS4Test.java
+++ b/src/test/java/AWS4Test.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -51,6 +52,14 @@ public class AWS4Test {
 	AmazonS3 svc = utils.getS3Client(useV4Signature);
 	String prefix = utils.getPrefix();
 	static Properties prop = new Properties();
+
+	@BeforeClass
+	public void generateFiles(){
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
+		filePath = "./data/file.txt";
+		utils.createFile(filePath, 256 * 1024);	
+	}
 
 	@AfterClass
 	public void tearDownAfterClass() throws Exception {
@@ -568,7 +577,7 @@ public class AWS4Test {
 		svc.createBucket(new CreateBucketRequest(bucket_name));
 
 		String filePath = "./data/file.mpg";
-		utils.createFile(filePath, 23 * 1024 * 1024);
+		utils.createFile(filePath, 53 * 1024 * 1024);
 
 		CompleteMultipartUploadRequest resp = utils.multipartUploadLLAPI(svc, bucket_name, key, 
 				5 * 1024 * 1024, filePath);
@@ -723,59 +732,54 @@ public class AWS4Test {
 
 	}
 
-	// The MultipartCopy test with LL API are commented out due to differences observed 
-	// in the HTTP response of the CopyPart request when running on master and mimic branches
-	// of Ceph
+	@Test(description = "multipart copy for small file using LLAPI, succeeds!")
+	public void testMultipartCopyMultipleSizesLLAPIAWS4() {
 
-	// @Test(description = "multipart copy for small file using LLAPI, succeeds!")
-	// public void testMultipartCopyMultipleSizesLLAPIAWS4() {
+		String src_bkt = utils.getBucketName(prefix);
+		String dst_bkt = utils.getBucketName(prefix);
+		String key = "key1";
 
-	// 	String src_bkt = utils.getBucketName(prefix);
-	// 	String dst_bkt = utils.getBucketName(prefix);
-	// 	String key = "key1";
+		svc.createBucket(new CreateBucketRequest(src_bkt));
+		svc.createBucket(new CreateBucketRequest(dst_bkt));
 
-	// 	svc.createBucket(new CreateBucketRequest(src_bkt));
-	// 	svc.createBucket(new CreateBucketRequest(dst_bkt));
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
+		File file = new File(filePath);
 
-	// 	String filePath = "./data/file.mpg";
-	// 	utils.createFile(filePath, 23 * 1024 * 1024);
-	// 	File file = new File(filePath);
-	// 	// Upload upl = utils.UploadFileHLAPI(svc, src_bkt, key, filePath);
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(file.length());
 
-	// 	ObjectMetadata metadata = new ObjectMetadata();
-	// 	metadata.setContentLength(file.length());
-
-	// 	try {
-	// 		svc.putObject(new PutObjectRequest(src_bkt, key, file));
-	// 	} catch (AmazonServiceException err) {
+		try {
+			svc.putObject(new PutObjectRequest(src_bkt, key, file));
+		} catch (AmazonServiceException err) {
 			
-	// 	}
+		}
 
-	// 	CompleteMultipartUploadRequest resp = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
-	// 			5 * 1024 * 1024);
-	// 	svc.completeMultipartUpload(resp);
+		CompleteMultipartUploadRequest resp = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				5 * 1024 * 1024);
+		svc.completeMultipartUpload(resp);
 
-	// 	CompleteMultipartUploadRequest resp2 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
-	// 			5 * 1024 * 1024 + 100 * 1024);
-	// 	svc.completeMultipartUpload(resp2);
+		CompleteMultipartUploadRequest resp2 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				5 * 1024 * 1024 + 100 * 1024);
+		svc.completeMultipartUpload(resp2);
 
-	// 	CompleteMultipartUploadRequest resp3 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
-	// 			5 * 1024 * 1024 + 600 * 1024);
-	// 	svc.completeMultipartUpload(resp3);
+		CompleteMultipartUploadRequest resp3 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				5 * 1024 * 1024 + 600 * 1024);
+		svc.completeMultipartUpload(resp3);
 
-	// 	CompleteMultipartUploadRequest resp4 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
-	// 			10 * 1024 * 1024 + 100 * 1024);
-	// 	svc.completeMultipartUpload(resp4);
+		CompleteMultipartUploadRequest resp4 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				10 * 1024 * 1024 + 100 * 1024);
+		svc.completeMultipartUpload(resp4);
 
-	// 	CompleteMultipartUploadRequest resp5 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
-	// 			10 * 1024 * 1024 + 600 * 1024);
-	// 	svc.completeMultipartUpload(resp5);
+		CompleteMultipartUploadRequest resp5 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				10 * 1024 * 1024 + 600 * 1024);
+		svc.completeMultipartUpload(resp5);
 
-	// 	CompleteMultipartUploadRequest resp6 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
-	// 			10 * 1024 * 1024);
-	// 	svc.completeMultipartUpload(resp6);
+		CompleteMultipartUploadRequest resp6 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				10 * 1024 * 1024);
+		svc.completeMultipartUpload(resp6);
 
-	// }
+	}
 
 	@Test(description = "Upload of a file using HLAPI, succeeds!")
 	public void testUploadFileHLAPIBigFileAWS4() {
@@ -819,6 +823,8 @@ public class AWS4Test {
 		svc.createBucket(new CreateBucketRequest(bucket_name));
 
 		String dir = "./data";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 
 		Transfer upl = utils.multipartUploadHLAPI(svc, bucket_name, null, dir);
 
@@ -833,6 +839,8 @@ public class AWS4Test {
 		String bucket_name = utils.getBucketName(prefix);
 
 		String dir = "./data";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 
 		try {
 			utils.multipartUploadHLAPI(svc, bucket_name, null, dir);
@@ -900,7 +908,8 @@ public class AWS4Test {
 		svc.createBucket(new CreateBucketRequest(src_bkt));
 		svc.createBucket(new CreateBucketRequest(dst_bkt));
 
-		String filePath = "./data/sample.txt";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 		Upload upl = utils.UploadFileHLAPI(svc, src_bkt, key, filePath);
 		Assert.assertEquals(upl.isDone(), true);
 
@@ -918,7 +927,8 @@ public class AWS4Test {
 
 		svc.createBucket(new CreateBucketRequest(src_bkt));
 
-		String filePath = "./data/sample.txt";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 		Upload upl = utils.UploadFileHLAPI(svc, src_bkt, key, filePath);
 		Assert.assertEquals(upl.isDone(), true);
 
@@ -971,7 +981,8 @@ public class AWS4Test {
 		svc.createBucket(new CreateBucketRequest(bucket_name));
 		String key = "key1";
 
-		String filePath = "./data/sample.txt";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 		Upload upl = utils.UploadFileHLAPI(svc, bucket_name, key, filePath);
 		Assert.assertEquals(upl.isDone(), true);
 

--- a/src/test/java/ObjectTest.java
+++ b/src/test/java/ObjectTest.java
@@ -1268,10 +1268,8 @@ public class ObjectTest {
 		Assert.assertEquals(list.isEmpty(), true);
 	}
 
-	@Test(description = "object list) w/ negative maxkeys, suceeds")
+	@Test(description = "object list w/ negative maxkeys, suceeds")
 	public void testObjectListMaxkeysNegative() {
-
-		// passes..wonder blandar
 
 		String[] keys = { "bar", "baz", "foo", "quxx" };
 
@@ -1279,8 +1277,8 @@ public class ObjectTest {
 		final ListObjectsV2Request req = new ListObjectsV2Request().withBucketName(bucket.getName()).withMaxKeys(-1);
 		ListObjectsV2Result result = svc.listObjectsV2(req);
 
-		Assert.assertEquals(result.getMaxKeys(), -1);
-		Assert.assertEquals(result.isTruncated(), true);
+		Assert.assertEquals(result.getMaxKeys(), 0);
+		Assert.assertEquals(result.isTruncated(), false);
 
 		Object[] k = new Object[] {};
 		ArrayList<Object> list = new ArrayList<Object>(Arrays.asList(k));

--- a/src/test/java/ObjectTest.java
+++ b/src/test/java/ObjectTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -63,6 +64,14 @@ public class ObjectTest {
 	boolean useV4Signature = false;
 	AmazonS3 svc = utils.getS3Client(useV4Signature);
 	String prefix = utils.getPrefix();
+
+	@BeforeClass
+	public void generateFiles(){
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
+		filePath = "./data/file.txt";
+		utils.createFile(filePath, 256 * 1024);	
+	}
 
 	@AfterClass
 	public void tearDownAfterClass() throws Exception {
@@ -1700,71 +1709,53 @@ public class ObjectTest {
 		}
 	}
 
-	// The MultipartCopy test with LL API are commented out due to differences
-	// observed
-	// in the HTTP response of the CopyPart request when running on master and mimic
-	// branches
-	// of Ceph
+	@Test(description = "multipart copy for small file using LLAPI, succeeds!")
+	public void testMultipartCopyMultipleSizesLLAPI() {
 
-	// @Test(description = "multipart copy for small file using LLAPI, succeeds!")
-	// public void testMultipartCopyMultipleSizesLLAPI() {
+		String src_bkt = utils.getBucketName(prefix);
+		String dst_bkt = utils.getBucketName(prefix);
+		String key = "key1";
 
-	// String src_bkt = utils.getBucketName(prefix);
-	// String dst_bkt = utils.getBucketName(prefix);
-	// String src_key = "src-key-0";
-	// String dst_key = "dst-key-1";
+		svc.createBucket(new CreateBucketRequest(src_bkt));
+		svc.createBucket(new CreateBucketRequest(dst_bkt));
 
-	// svc.createBucket(new CreateBucketRequest(src_bkt));
-	// svc.createBucket(new CreateBucketRequest(dst_bkt));
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
+		File file = new File(filePath);
 
-	// String filePath = "./data/file.mpg";
-	// utils.createFile(filePath, 23 * 1024 * 1024);
-	// // Upload upl = utils.UploadFileHLAPI(svc, src_bkt, src_key, filePath);
-	// // Assert.assertEquals(upl.isDone(), true);
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(file.length());
 
-	// File file = new File(filePath);
-	// // Upload upl = utils.UploadFileHLAPI(svc, src_bkt, key, filePath);
+		try {
+			svc.putObject(new PutObjectRequest(src_bkt, key, file));
+		} catch (AmazonServiceException err) {
 
-	// ObjectMetadata metadata = new ObjectMetadata();
-	// metadata.setContentLength(file.length());
+		}
 
-	// try {
-	// svc.putObject(new PutObjectRequest(src_bkt, src_key, file));
-	// } catch (AmazonServiceException err) {
+		CompleteMultipartUploadRequest resp = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				5 * 1024 * 1024);
+		svc.completeMultipartUpload(resp);
 
-	// }
+		CompleteMultipartUploadRequest resp2 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				5 * 1024 * 1024 + 100 * 1024);
+		svc.completeMultipartUpload(resp2);
 
-	// CompleteMultipartUploadRequest resp = utils.multipartCopyLLAPI(svc, dst_bkt,
-	// dst_key, src_bkt, src_key,
-	// 5 * 1024 * 1024);
-	// S3.logger.debug(String.format("TEST ERROR: %s%n", err.getMessage()));
-	// svc.completeMultipartUpload(resp);
+		CompleteMultipartUploadRequest resp3 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				5 * 1024 * 1024 + 600 * 1024);
+		svc.completeMultipartUpload(resp3);
 
-	// CompleteMultipartUploadRequest resp2 = utils.multipartCopyLLAPI(svc, dst_bkt,
-	// dst_key, src_bkt, src_key,
-	// 5 * 1024 * 1024 + 100 * 1024);
-	// svc.completeMultipartUpload(resp2);
+		CompleteMultipartUploadRequest resp4 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				10 * 1024 * 1024 + 100 * 1024);
+		svc.completeMultipartUpload(resp4);
 
-	// CompleteMultipartUploadRequest resp3 = utils.multipartCopyLLAPI(svc, dst_bkt,
-	// dst_key, src_bkt, src_key,
-	// 5 * 1024 * 1024 + 600 * 1024);
-	// svc.completeMultipartUpload(resp3);
+		CompleteMultipartUploadRequest resp5 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				10 * 1024 * 1024 + 600 * 1024);
+		svc.completeMultipartUpload(resp5);
 
-	// CompleteMultipartUploadRequest resp4 = utils.multipartCopyLLAPI(svc, dst_bkt,
-	// dst_key, src_bkt, src_key,
-	// 10 * 1024 * 1024 + 100 * 1024);
-	// svc.completeMultipartUpload(resp4);
-
-	// CompleteMultipartUploadRequest resp5 = utils.multipartCopyLLAPI(svc, dst_bkt,
-	// dst_key, src_bkt, src_key,
-	// 10 * 1024 * 1024 + 600 * 1024);
-	// svc.completeMultipartUpload(resp5);
-
-	// CompleteMultipartUploadRequest resp6 = utils.multipartCopyLLAPI(svc, dst_bkt,
-	// dst_key, src_bkt, src_key,
-	// 10 * 1024 * 1024);
-	// svc.completeMultipartUpload(resp6);
-	// }
+		CompleteMultipartUploadRequest resp6 = utils.multipartCopyLLAPI(svc, dst_bkt, key, src_bkt, key,
+				10 * 1024 * 1024);
+		svc.completeMultipartUpload(resp6);
+	}
 
 	@Test(description = "Upload of a  file using HLAPI, succeeds!")
 	public void testUploadFileHLAPIBigFile() {
@@ -1806,6 +1797,8 @@ public class ObjectTest {
 		svc.createBucket(new CreateBucketRequest(bucket_name));
 
 		String dir = "./data";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 
 		Transfer upl = utils.multipartUploadHLAPI(svc, bucket_name, null, dir);
 
@@ -1819,6 +1812,8 @@ public class ObjectTest {
 		String bucket_name = utils.getBucketName(prefix);
 
 		String dir = "./data";
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 
 		try {
 			utils.multipartUploadHLAPI(svc, bucket_name, null, dir);
@@ -1836,17 +1831,18 @@ public class ObjectTest {
 		svc.createBucket(new CreateBucketRequest(bucket_name));
 
 		String filePath = "./data/file.mpg";
-		utils.createFile(filePath, 23 * 1024 * 1024);
+		utils.createFile(filePath, 53 * 1024 * 1024);
 		String key = "key1";
 
-		TransferManager tm = TransferManagerBuilder.standard().withS3Client(svc).build();
+		TransferManager tm = TransferManagerBuilder.standard().withS3Client(svc)
+				.withMultipartUploadThreshold(256 * 1024l).withMinimumUploadPartSize(256 * 1024l).build();
 		Upload myUpload = tm.upload(bucket_name, key, new File(filePath));
 
 		// pause upload
-		long MB = 10;
 		TransferProgress progress = myUpload.getProgress();
-		while (progress.getBytesTransferred() < MB)
-			Thread.sleep(2000);
+		long MB = 5 * 1024 * 1024l;
+		while (progress.getBytesTransferred() < MB) 
+			Thread.sleep(200);
 
 		if (progress.getBytesTransferred() < progress.getTotalBytesToTransfer()) {
 			boolean forceCancel = true;
@@ -1880,8 +1876,8 @@ public class ObjectTest {
 		svc.createBucket(new CreateBucketRequest(src_bkt));
 		svc.createBucket(new CreateBucketRequest(dst_bkt));
 
-		String filePath = "./data/sample.txt";
-		utils.createFile(filePath, 256 * 1024);
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 		Upload upl = utils.UploadFileHLAPI(svc, src_bkt, key, filePath);
 		Assert.assertEquals(upl.isDone(), true);
 
@@ -1899,8 +1895,8 @@ public class ObjectTest {
 
 		svc.createBucket(new CreateBucketRequest(src_bkt));
 
-		String filePath = "./data/sample.txt";
-		utils.createFile(filePath, 256 * 1024);
+		String filePath = "./data/file.mpg";
+		utils.createFile(filePath, 23 * 1024 * 1024);
 		Upload upl = utils.UploadFileHLAPI(svc, src_bkt, key, filePath);
 		Assert.assertEquals(upl.isDone(), true);
 


### PR DESCRIPTION
The ObjectTest.testObjectListMaxkeysNegative was failing due to changed behavior in the result of ListObjectsV2Request. The result method getMaxKeys() returns 0 when the request is constructed using withMaxKeys(-1). The same behavior has been confirmed with boto3 SDK.