### PR TITLE
bootstrap.sh: gradle 6.0.1

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -68,7 +68,7 @@ echo " Gradle will be installed under $GRADLEPATH"
 
 # The version is hardcoded on purpose in order to match the 
 # one used for testing in the Ceph test framework Teuthology
-version=4.7
+version=6.0.1
 
 if [ ! -d /opt/gradle ]; then
     sudo mkdir ${GRADLEPATH}


### PR DESCRIPTION
Moving to 6.0.1 fixes things on master.

Signed-off-by: Sage Weil <sage@redhat.com>