### PR TITLE
flatten testUploadFileList, don't catch exceptions

### DIFF
--- a/src/main/java/S3.java
+++ b/src/main/java/S3.java
@@ -427,28 +427,6 @@ public class S3 {
 		return upload;
 	}
 
-	public MultipleFileUpload UploadFileListHLAPI(AmazonS3 svc, String bucket, String key)
-			throws AmazonServiceException, AmazonClientException, InterruptedException {
-
-		ArrayList<File> files = new ArrayList<File>();
-
-		String fname1 = "./data/file.mpg";
-		String fname2 = "./data/sample.txt";
-		createFile(fname1, 23 * 1024 * 1024);
-		createFile(fname2, 256 * 1024);
-		files.add(new File(fname1));
-		files.add(new File(fname2));
-
-		TransferManager tm = TransferManagerBuilder.standard().withS3Client(svc).build();
-		MultipleFileUpload xfer = tm.uploadFileList(bucket, key, new File("."), files);
-		try {
-			waitForCompletion(xfer);
-		} catch (AmazonServiceException e) {
-
-		}
-		return xfer;
-	}
-
 	public Transfer multipartUploadHLAPI(AmazonS3 svc, String bucket, String s3target, String directory)
 			throws AmazonServiceException, AmazonClientException, InterruptedException {
 


### PR DESCRIPTION
removed helper function UploadFileListHLAPI() and moved its test logic into testUploadFileList() with try/catch removed. too many exceptions were being ignored by catch {} blocks to tell what actually causes failures

an example failure (caused by not starting a radosgw) now looks like this:
```
suite > Object tests > ObjectTest.testUploadFileList FAILED
    com.amazonaws.SdkClientException at ObjectTest.java:2136
        Caused by: org.apache.http.conn.HttpHostConnectException at ObjectTest.java:2136
            Caused by: java.net.ConnectException at ObjectTest.java:2136
```