### PR TITLE
use empty string for TestObjectCreateBadMd5Empty

### DIFF
--- a/src/test/java/ObjectTest.java
+++ b/src/test/java/ObjectTest.java
@@ -602,7 +602,7 @@ public class ObjectTest {
 			String bucket_name = utils.getBucketName(prefix);
 			String key = "key1";
 			String content = "echo lima golf";
-			String md5 = " ";
+			String md5 = "";
 
 			svc.createBucket(new CreateBucketRequest(bucket_name));
 
@@ -614,9 +614,10 @@ public class ObjectTest {
 			metadata.setHeader("Content-MD5", md5);
 
 			svc.putObject(new PutObjectRequest(bucket_name, key, is, metadata));
-			AssertJUnit.fail("Expected 400 Bad Request");
+			AssertJUnit.fail("Expected 400 InvalidDigest");
 		} catch (AmazonServiceException err) {
-			AssertJUnit.assertEquals(err.getErrorCode(), "400 Bad Request");
+			AssertJUnit.assertEquals(err.getStatusCode(), 400);
+			AssertJUnit.assertEquals(err.getErrorCode(), "InvalidDigest");
 		}
 	}
 


### PR DESCRIPTION
this test case has been passing, but not in the way in we thought

the use of " " here was actually causing 403 SignatureDoesNotMatch; apparently because java is signing the header value of " ", where boto and radosgw are stripping that whitespace from header values when calculating the signature

on 403 errors, the java client retries this request. because of a separate bug https://tracker.ceph.com/issues/58286 in radosgw's http parser, the retried request failed with 500 Bad Request

500 errors aren't retried, so this is the error code caught by the test case

this test case was copied from test_object_create_bad_md5_empty() in s3-tests, where it instead expects 400 InvalidDigest