### PR TITLE
remove unnecessary test testObjectCreateBadContentlengthNegative

### DIFF
--- a/src/test/java/ObjectTest.java
+++ b/src/test/java/ObjectTest.java
@@ -451,31 +451,6 @@ public class ObjectTest {
 	}
         */
 
-	@Test(description = "object create w/negative content length, fails")
-	public void testObjectCreateBadContentlengthNegative() {
-
-		try {
-			String bucket_name = utils.getBucketName(prefix);
-			String key = "key1";
-			String content = "echo lima golf";
-			long contlength = -1;
-
-			svc.createBucket(new CreateBucketRequest(bucket_name));
-
-			byte[] contentBytes = content.getBytes(StringUtils.UTF8);
-			InputStream is = new ByteArrayInputStream(contentBytes);
-
-			ObjectMetadata metadata = new ObjectMetadata();
-			metadata.setHeader("Content-Length", contlength);
-
-			svc.putObject(new PutObjectRequest(bucket_name, key, is, metadata));
-			AssertJUnit.fail("Expected 411 MissingContentLength");
-		} catch (AmazonServiceException err) {
-			AssertJUnit.assertNotSame(err.getLocalizedMessage(), null);
-			AssertJUnit.assertEquals(err.getErrorCode(), "MissingContentLength");
-		}
-	}
-
         /*
 	@Test(description = "object create w/empty Expect, succeeds")
 	public void testObjectCreateBadExpectEmpty() {


### PR DESCRIPTION
following ceph PR https://github.com/ceph/ceph/pull/50235 it was found that the test 'object create w/negative content length, fails' test falsely fails on object PUT with chunked transfer encoding and does not attempts to create an object with a negative content length for details referring to discussion on: https://github.com/ceph/java_s3tests/pull/13