### PR TITLE
README: update URL for ceph fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The test suite only covers the REST interface and uses [AWS Java SDK ](https://a
 
 Clone the repository
 
-	git clone https://github.com/adamyanova/java_s3tests
+	git clone https://github.com/ceph/java_s3tests
 
 ### Edit Configuration
 


### PR DESCRIPTION
Point users at Ceph's copy of this repository, rather than the earlier fork. Ceph's copy has additional fixes that are not in the older repo.

Discovered while testing the fix for https://tracker.ceph.com/issues/64549