### PR TITLE
bootstrap: rpm distros use "latest" openjdk packages

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -68,7 +68,7 @@ echo " Gradle will be installed under $GRADLEPATH"
 
 # The version is hardcoded on purpose in order to match the 
 # one used for testing in the Ceph test framework Teuthology
-version=6.0.1
+version=9.4.1
 
 if [ ! -d /opt/gradle ]; then
     sudo mkdir ${GRADLEPATH}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,7 +37,7 @@ if [ -f /etc/debian_version ]; then
         sudo apt-get -y install $missing
     fi
 elif [ -f /etc/fedora-release ]; then
-    for package in java-1.8.0-openjdk wget unzip; do
+    for package in java-latest-openjdk wget unzip; do
         if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
             missing="${missing:+$missing }$package"
         fi
@@ -47,7 +47,7 @@ elif [ -f /etc/fedora-release ]; then
         sudo yum -y install $missing
     fi
 elif [ -f /etc/redhat-release ]; then
-    for package in java-1.8.0-openjdk java-1.8.0-openjdk-devel wget unzip; do
+    for package in java-latest-openjdk java-latest-openjdk-devel wget unzip; do
         if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
             missing="${missing:+$missing }$package"
         fi


### PR DESCRIPTION
avoid specifying an openjdk version, just use "latest"

Fixes: https://tracker.ceph.com/issues/73678