### PR TITLE
rgw/test: install Java 8 under rocky linux

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,6 +36,21 @@ if [ -f /etc/debian_version ]; then
         echo "$0: missing required DEB packages. Installing via sudo." 1>&2
         sudo apt-get -y install $missing
     fi
+elif [ -f /etc/rocky-release ]; then
+    # need to check for /etc/rocky-release before /etc/redhat-release
+    # since both present
+    for package in wget unzip epel-release; do
+        if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
+            missing="${missing:+$missing }$package"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        echo "$0: missing required RPM packages. Installing via sudo." 1>&2
+        sudo dnf -y install $missing
+    fi
+    sudo dnf -y install adoptium-temurin-java-repository
+    sudo dnf config-manager --set-enabled adoptium-temurin-java-repository
+    sudo dnf -y install temurin-8-jdk
 elif [ -f /etc/fedora-release ]; then
     for package in java-1.8.0-openjdk wget unzip; do
         if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then


### PR DESCRIPTION
Updates the bootstrap.sh script so it can install a version of Java 8.

Note: this depends on https://github.com/ceph/ceph/pull/68208 .

Fixes: https://tracker.ceph.com/issues/73678